### PR TITLE
Fix entry editing for cms > 3.0.2

### DIFF
--- a/multilingual_news/templates/multilingual_news/partials/entry.html
+++ b/multilingual_news/templates/multilingual_news/partials/entry.html
@@ -44,12 +44,10 @@
 {% endif %}
 
 {% if not preview and request.toolbar.edit_mode %}
-    {% render_placeholder news_entry.excerpt as excerpt %}
-    {{ excerpt }}
+    {% render_placeholder news_entry.excerpt %}
 {% endif %}
 
-{% render_placeholder news_entry.content as text %}
-{{ text }}
+{% render_placeholder news_entry.content %}
 
 <p><a href="{% url "news_list" %}">{% trans "Back to article list" %}</a></p>
 


### PR DESCRIPTION
In cms 3.0.2 they introduced accepting the `as` argument.  When as is passed the placeholder is longer editable when in edit mode.  Current use of `as` makes news articles essentially no longer editable.  This fixes that problem.